### PR TITLE
Fix unrecognized arguments

### DIFF
--- a/reminders_client_utils.py
+++ b/reminders_client_utils.py
@@ -33,6 +33,7 @@ def authenticate() -> httplib2.Http:
                 scope=['https://www.googleapis.com/auth/reminders'],
                 user_agent='google reminders cli tool'),
             storage,
+            tools.argparser.parse_args([])
         )
     auth_http = credentials.authorize(httplib2.Http())
     return auth_http


### PR DESCRIPTION
The args parser is overlapping with oauth2client.tools parser, so the google parser was reading over remind.py args