### PR TITLE
add full path when searching app_keys.json

### DIFF
--- a/reminders_client_utils.py
+++ b/reminders_client_utils.py
@@ -9,7 +9,7 @@ from oauth2client.file import Storage
 
 from reminder import Reminder
 
-APP_KEYS_FILE = 'app_keys.json'
+APP_KEYS_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'app_keys.json')
 USER_OAUTH_DATA_FILE = os.path.expanduser('~/.google-reminders-cli-oauth')
 
 


### PR DESCRIPTION
When searching for app_keys.json the full path is provided, this allows the script to be executed anywhere, no matter where the script is invoked.